### PR TITLE
Java overload tag

### DIFF
--- a/tempo/src/main/java/io/tempo/Tempo.kt
+++ b/tempo/src/main/java/io/tempo/Tempo.kt
@@ -34,7 +34,7 @@ object Tempo {
     private val eventsSubject = ReplayProcessor.createWithTime<TempoEvent>(
             1000, TimeUnit.MILLISECONDS, Schedulers.io())
 
-
+    @JvmOverloads
     fun initialize(
             application: Application,
             timeSources: List<TimeSource> = listOf(SlackSntpTimeSource()),


### PR DESCRIPTION
I added the @JvmOverloads tag in order to enable users to use function initialize() from Java classes.