### PR TITLE
Adds Tempo::now

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ A `null` is returned when *Tempo* has not been initialized yet.
 When initialized, `Tempo::nowOrNull()` returns the current
 [unix epoch time](https://www.epochconverter.com/) in milliseconds.
 
+**Tip:** Avoid using `Tempo::nowOrNull()` for critical operations that requires the time.
+Use `Tempo::now()` as it'll return a result whenever one is available.
+
 You can observe all the events emitted by the library:
 
     Tempo.addEventsListener { event -> Log.d("TempoEvent", event.toString()) }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 ext {
     def versionMajor = 1
-    def versionMinor = 1
+    def versionMinor = 2
     def versionPatch = 0
     def versionCode = versionPatch + versionMinor * 100 + versionMajor * 10000
 
@@ -20,11 +20,11 @@ buildscript {
     ext {
         depPaths = {
             def versions = [
-                    gradlePlugin  : '4.1.1',
+                    gradlePlugin  : '4.2.1',
                     androidJunit5 : '1.6.2.0',
                     versions      : '0.36.0',
-                    kotlin        : '1.4.10',
-                    coroutines    : '1.4.1',
+                    kotlin        : '1.5.10',
+                    coroutines    : '1.5.0',
                     appCompat     : '1.2.0',
                     material      : '1.2.0',
                     workManager   : '2.4.0',

--- a/sample/src/main/java/io/tempo/sample/MainActivity.kt
+++ b/sample/src/main/java/io/tempo/sample/MainActivity.kt
@@ -35,6 +35,7 @@ import io.tempo.TempoEventsListener
 import io.tempo.sample.databinding.ActivityMainBinding
 import io.tempo.sample.databinding.ItemTempoEventBinding
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.collect
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -68,6 +69,13 @@ class MainActivity : AppCompatActivity() {
 
         scope = CoroutineScope(Dispatchers.Main).apply {
             launch {
+                async {
+                    delay(10_000L) // simulates late initialization
+                    Tempo.now().collect { now ->
+                        Log.d("TempoEvent", "This is now: ${formatTimestamp(now)}")
+                    }
+                }
+
                 while (isActive) {
                     val systemTime = System.currentTimeMillis()
                     val tempoTime = Tempo.nowOrNull()
@@ -87,8 +95,10 @@ class MainActivity : AppCompatActivity() {
         Tempo.addEventsListener(listener)
 
         if (!hasGPSPermission()) {
-            ActivityCompat.requestPermissions(this,
-                listOf(Manifest.permission.ACCESS_FINE_LOCATION).toTypedArray(), 42)
+            ActivityCompat.requestPermissions(
+                this,
+                listOf(Manifest.permission.ACCESS_FINE_LOCATION).toTypedArray(), 42
+            )
         }
     }
 
@@ -103,8 +113,10 @@ class MainActivity : AppCompatActivity() {
 
     private fun hasGPSPermission(): Boolean {
 
-        return ContextCompat.checkSelfPermission(this,
-            Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
+        return ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
     }
 
     private val listener = TempoEventsListener { event -> eventsRvAdapter?.addEvent(event) }

--- a/tempo/src/main/java/io/tempo/Tempo.kt
+++ b/tempo/src/main/java/io/tempo/Tempo.kt
@@ -25,6 +25,7 @@ import io.tempo.internal.domain.useCases.*
 import io.tempo.internal.log
 import io.tempo.schedulers.NoOpScheduler
 import io.tempo.timeSources.SlackSntpTimeSource
+import kotlinx.coroutines.flow.Flow
 
 public object Tempo {
     private var instance: TempoInstance? = null
@@ -62,7 +63,8 @@ public object Tempo {
 
             // UseCases
             val syncTimeSourcesUC = SyncTimeSourcesUC(
-                timeSources, storage, deviceClocks, tempoEventLooper)
+                timeSources, storage, deviceClocks, tempoEventLooper
+            )
             val periodicallySyncUC = PeriodicallySyncUC(autoSyncConfig, syncTimeSourcesUC)
             val checkCacheValidityUC = CheckCacheValidityUC(deviceClocks)
             val getBestAvailableTimeSourceUC =
@@ -84,6 +86,24 @@ public object Tempo {
     @JvmStatic
     public fun isInitialized(): Boolean = instance?.initialized == true
 
+    /**
+     * Get the current time. This should be called only after Tempo
+     * is initialized.
+     *
+     * This function will return the current time if available, otherwise, it'll wait for Tempo
+     * to finish initializing before returning a result.
+     */
+    public fun now(): Flow<Long> = requireInstance().now()
+
+    /**
+     * Get the current time with a non-blocking operation. This should be called only after Tempo
+     * is initialized.
+     *
+     * If this function is called before a successfully sync operation,
+     * or if the cache is outdated, it'll return null.
+     *
+     * Use it with cautious. Prefer using [Tempo::now] for a safer option.
+     */
     @JvmStatic
     public fun nowOrNull(): Long? = requireInstance().nowOrNull()
 

--- a/tempo/src/main/java/io/tempo/internal/TempoInstance.kt
+++ b/tempo/src/main/java/io/tempo/internal/TempoInstance.kt
@@ -25,8 +25,10 @@ import io.tempo.internal.domain.useCases.PeriodicallySyncUC
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BroadcastChannel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
 
 internal class TempoInstance(
     private val periodicallySyncUC: PeriodicallySyncUC,
@@ -73,5 +75,8 @@ internal class TempoInstance(
     }
 
     fun nowOrNull(): Long? = activeTimeWrapper?.let(getTimeNowUC::invoke)
+
+    fun now(): Flow<Long> = getBestAvailableTimeSourceUC().map(getTimeNowUC::invoke)
+
     fun activeTimeSourceId(): String? = activeTimeWrapper?.timeSource?.config?.id
 }


### PR DESCRIPTION
Tempo currently doesn't have a good way to safely get the time whenever it becomes available. We had to either manually check if it was initialized, or rely on unreliable TempoEvents.

A new funciton, `Tempo::now` solves this issue by reactively exposing the current time.

See #18 