### PR TITLE
Fix bug in SNTP synchronization

### DIFF
--- a/tempo/src/main/java/io/tempo/internal/domain/useCases/SyncTimeSourcesUC.kt
+++ b/tempo/src/main/java/io/tempo/internal/domain/useCases/SyncTimeSourcesUC.kt
@@ -56,8 +56,8 @@ internal class SyncTimeSourcesUC(
             timeSourceId = timeSource.config.id,
             timeSourcePriority = timeSource.config.priority,
             estimatedBootTime = deviceClocks.estimatedBootTime(),
-            requestDeviceUptime = deviceClocks.uptime(),
-            requestTime = requestTime,
+            requestDeviceUptime = requestTime.requestUptime,
+            requestTime = requestTime.requestTime,
             bootCount = deviceClocks.bootCount()
         )
 

--- a/tempo/src/main/java/io/tempo/time_source.kt
+++ b/tempo/src/main/java/io/tempo/time_source.kt
@@ -22,13 +22,11 @@ package io.tempo
  */
 public data class TimeSourceConfig(val id: String, val priority: Int)
 
+public data class TimeSyncInfo(val requestTime: Long, val requestUptime: Long)
+
 public interface TimeSource {
     public val config: TimeSourceConfig
-
-    /**
-     * @return A single containing the unix epoch time in milliseconds, or an error.
-     */
-    public suspend fun requestTime(): Long
+    public suspend fun requestTime(): TimeSyncInfo
 }
 
 public data class TimeSourceCache(


### PR DESCRIPTION
Correct the internal cache update to use the proper uptime reference. Previously, an incorrect reference introduced a minor error (a few milliseconds or less). In cases where NTP requests timed out, this error could increase significantly, reaching up to 10 seconds (the default timeout value).